### PR TITLE
Define STRICT_R_HEADERS and use M_PI

### DIFF
--- a/src/CovCMBHelpers.cpp
+++ b/src/CovCMBHelpers.cpp
@@ -1,3 +1,4 @@
+#define STRICT_R_HEADERS
 #include <Rcpp.h>
 using namespace Rcpp;
 

--- a/src/Manipulation.cpp
+++ b/src/Manipulation.cpp
@@ -1,4 +1,5 @@
 //Includes/namespaces
+#define STRICT_R_HEADERS
 #include <Rcpp.h>
 using namespace Rcpp;
 
@@ -339,7 +340,7 @@ NumericMatrix pix2coords_internal(int nside = 0,
       i = floor(sqrt(ph-sqrt(floor(ph)))) + 1;
       j = p + 1 - 2*i*(i-1);
       z = 1 - i*i/fact2;
-      phi = (j - 0.5)*PI/(2.0*i);
+      phi = (j - 0.5)*M_PI/(2.0*i);
 
     } else if (p <= bpiRingSE){
 
@@ -349,7 +350,7 @@ NumericMatrix pix2coords_internal(int nside = 0,
 
       double s = 0.5*(1 + ((i + nside) % 2));
       z =  (nl2 - i)/fact1;
-      phi = (j - s)*PI/(2.0*nside);
+      phi = (j - s)*M_PI/(2.0*nside);
 
     } else { // South Polar pixel
 
@@ -358,7 +359,7 @@ NumericMatrix pix2coords_internal(int nside = 0,
       i = floor(sqrt(ph-sqrt(floor(ph)))) + 1;
       j = 4*i + 1 - (ps - 2*i*(i-1));
       z = i*i/fact2 - 1;
-      phi = (j - 0.5)*PI/(2*i);
+      phi = (j - 0.5)*M_PI/(2*i);
 
     }
 

--- a/src/MathHelpers.cpp
+++ b/src/MathHelpers.cpp
@@ -1,3 +1,4 @@
+#define STRICT_R_HEADERS
 #include <Rcpp.h>
 using namespace Rcpp;
 


### PR DESCRIPTION
Dear Daniel,

Your CRAN package rcosmo uses Rcpp, and is affected if we add a definition of STRICT_R_HEADERS as we would like to do. Please see the discussion at https://github.com/RcppCore/Rcpp/issues/1158 and the links therein for more context on this.

Here, we prefixed three #include <Rcpp.h> with STRICT_R_HEADERS. The actual change that is needed is the change from PI to M_PI in one file.

It would be lovely if you could apply this. There is no strong urgency: we aim to get this done over all affected packages in the space of a few months. If you apply it, would you mind dropping me a note by email or swinging by https://github.com/RcppCore/Rcpp/issues/1158 to confirm?

Many thanks for your help, and I hope you continue to find Rcpp helpful. Please don't hesitate to ask if you have any questions.